### PR TITLE
Fixed return data error caused due to custom_query and custom_query_range methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ check_prometheus_connection(self, params: dict = None)
 The `check_prometheus_connection` function enables you to check the connection status with the Prometheus instance. You can pass an optional dictionary of parameters to customize the connection check. This function returns true if it is able to connect.
 
 
+```
+safe_custom_query_range
+```
+
+The `safe_custom_query_range` function retrieves time-series data from Prometheus over a specified range. It returns the queried data in JSON format or raises an exception if the request fails.
+
+**Differences between `custom_query_range` and `safe_custom_query_range`:**
+- `custom_query_range` is a feature of the `prometheus_api_client` library, utilized internally by Prometrix.
+- `safe_custom_query_range` returns the entire `data` dictionary from the Prometheus query response, whereas `custom_query_range` only returns the `result` section.
+
+```
+safe_custom_query
+```
+The `safe_custom_query` function executes a single-point Prometheus query and returns the result in JSON format. It throws an exception in the event of an error.
+
+**Differences between `custom_query` and `safe_custom_query`:**
+- `custom_query` is part of the `prometheus_api_client` library, used internally by Prometrix.
+- `safe_custom_query` returns the complete `data` dictionary of the Prometheus query response, in contrast to `custom_query`, which only returns the `result` section.
+
+
 Contributing
 ------------
 

--- a/prometrix/connect/aws_connect.py
+++ b/prometrix/connect/aws_connect.py
@@ -63,7 +63,7 @@ class AWSPrometheusConnect(CustomPrometheusConnect):
         )
         return response
 
-    def custom_query_range(
+    def safe_custom_query_range(
         self,
         query: str,
         start_time: datetime,

--- a/prometrix/connect/custom_connect.py
+++ b/prometrix/connect/custom_connect.py
@@ -22,7 +22,7 @@ class CustomPrometheusConnect(PrometheusConnect):
         self._session = requests.Session()
         self._session.mount(self.url, HTTPAdapter(pool_maxsize=10, pool_block=True))
 
-    def custom_query_range(
+    def safe_custom_query_range(
         self,
         query: str,
         start_time: datetime,
@@ -81,7 +81,7 @@ class CustomPrometheusConnect(PrometheusConnect):
             raise PrometheusApiClientException("Labels Api not supported")
         return super().get_label_values(label_name, params)
 
-    def custom_query(self, query: str, params: dict = None):
+    def safe_custom_query(self, query: str, params: dict = None):
         response = self._custom_query(query, params)
         if response.status_code == 200:
             data = response.json()["data"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prometrix"
-version = "0.1.15"
+version = "0.1.16"
 authors = ["Avi Kotlicky <avi@robusta.dev>"]
 readme = "README.md"
 packages = [{include = "prometrix"}]

--- a/tests/main.py
+++ b/tests/main.py
@@ -54,7 +54,7 @@ def run_test(test_type: str, config: PrometheusConfig):
         if not test_label(prom_cli):
             print(f"Test {test_type} failed, error with label api")
             return
-        result = prom_cli.custom_query_range(
+        result = prom_cli.safe_custom_query_range(
             query="container_memory_working_set_bytes",
             start_time=datetime.now() - timedelta(days=1),
             end_time=datetime.now(),


### PR DESCRIPTION
Replaced the methods: custom_query and custom_query_range with safe_custom_query and safe_custom_query_range respectively for both CustomPrometheusConnect and AWSPrometheusConnect