### PR TITLE
Add session token to the AWS credentials

### DIFF
--- a/prometrix/connect/aws_connect.py
+++ b/prometrix/connect/aws_connect.py
@@ -12,10 +12,10 @@ from prometrix.connect.custom_connect import CustomPrometheusConnect
 
 class AWSPrometheusConnect(CustomPrometheusConnect):
     def __init__(
-        self, access_key: str, secret_key: str, region: str, service_name: str, **kwargs
+        self, access_key: str, secret_key: str, region: str, service_name: str, token: Optional[str] = None, **kwargs
     ):
         super().__init__(**kwargs)
-        self._credentials = Credentials(access_key, secret_key)
+        self._credentials = Credentials(access_key, secret_key, token)
         self._sigv4auth = S3SigV4Auth(self._credentials, service_name, region)
 
     def signed_request(

--- a/prometrix/models/prometheus_config.py
+++ b/prometrix/models/prometheus_config.py
@@ -32,6 +32,7 @@ class PrometheusConfig(BaseModel):
 class AWSPrometheusConfig(PrometheusConfig):
     access_key: str
     secret_access_key: str
+    token: Optional[str] = None
     service_name: str = "aps"
     aws_region: str
     supported_apis: List[PrometheusApis] = [

--- a/prometrix/utils.py
+++ b/prometrix/utils.py
@@ -37,6 +37,7 @@ def get_custom_prometheus_connect(
             service_name=prom_config.service_name,
             region=prom_config.aws_region,
             config=prom_config,
+            token=prom_config.token,
         )
     else:
         prom = CustomPrometheusConnect(config=prom_config)


### PR DESCRIPTION
Hello.

Currently this library can't be used with STS tokens and botocore library supports it in Credentials() class as a 3rd optional argument (token).
